### PR TITLE
Add missing dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+wb-mqtt-urri (1.0.4) stable; urgency=medium
+
+  * Add missing dependency (python3-websocket)
+  * Enhance debug logging
+
 wb-mqtt-urri (1.0.3) stable; urgency=medium
 
   * Add retain flags to meta topics

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/wirenboard/wb-mqtt-urri
 
 Package: wb-mqtt-urri
 Architecture: all
-Depends: ${misc:Depends}, python3:any (>= 3.9.0), python3-wb-common (>= 2.1.0~~), python3-socketio, python3-requests, python3-pyinotify
+Depends: ${misc:Depends}, python3:any (>= 3.9.0), python3-wb-common (>= 2.1.0~~), python3-socketio, python3-requests, python3-pyinotify, python3-websocket
 Description: Wiren Board URRI receiver (MQTT driver)
  It uses URRI API (ver. 2.16.15) for connect to receiver,
  get status data from it and send commands.

--- a/wb-mqtt-urri
+++ b/wb-mqtt-urri
@@ -40,7 +40,7 @@ class ConfigHandler(pyinotify.ProcessEvent):
 
 
 # initialize socket.io client
-urriClient = socketio.Client()
+urriClient = socketio.Client(logger=debug, engineio_logger=debug)
 
 # initialize mqtt client
 mqttClient = MQTTClient("wb-mqtt-urri", mqtt_url)


### PR DESCRIPTION
Failed to establish connection:
```sh
May 05 09:06:51 wirenboard-ALAPXQFI wb-mqtt-urri[9470]: Attempting polling connection to http://192.168.2.103:9032/socket.io/?transport=polling&EIO=4
May 05 09:06:51 wirenboard-ALAPXQFI wb-mqtt-urri[9470]: Polling connection accepted with {'sid': 'pD2wIoCr_M8NSRywAABA', 'upgrades': ['websocket'], 'pingInterval': 25000, 'pingTimeout': 20000, 'maxPayload': 1000000}
May 05 09:06:51 wirenboard-ALAPXQFI wb-mqtt-urri[9470]: Engine.IO connection established
May 05 09:06:51 wirenboard-ALAPXQFI wb-mqtt-urri[9470]: Sending packet MESSAGE data 0
May 05 09:06:51 wirenboard-ALAPXQFI wb-mqtt-urri[9470]: websocket-client package not installed, only polling transport is available
```