### PR TITLE
Add alerts, presets and usb folders playing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-urri (1.2.0) stable; urgency=medium
+
+  * Fix AUX mode
+  * Add alerts, presets and usb folders playing
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Wed, 24 Jan 2024 13:40:50 +0300
+
 wb-mqtt-urri (1.1.1) stable; urgency=medium
 
   * Fix deps

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -218,20 +218,22 @@ class MQTTDevice:
         logger.info("Play previous track on URRI %s", self._urri_device.title)
 
     def _on_message_play_folder(self, _, __, msg):
-        result = self._urri_device.play_usb_folder(msg.payload.decode("utf-8"))
+        folder = msg.payload.decode("utf-8")
+        result = self._urri_device.play_usb_folder(folder)
         self._device.set_control_error("Play Folder", "" if result else "w")
         if result:
-            logger.info("Play USB folder %s on URRI %s", msg, self._urri_device.title)
+            logger.info("Play USB folder %s on URRI %s", folder, self._urri_device.title)
         else:
-            logger.warning("USB Folder %s not found on URRI %s", msg, self._urri_device.title)
+            logger.warning("USB Folder %s not found on URRI %s", folder, self._urri_device.title)
 
     def _on_message_play_alert(self, _, __, msg):
-        result = self._urri_device.play_alert_by_name(msg.payload.decode("utf-8"))
+        alert = msg.payload.decode("utf-8")
+        result = self._urri_device.play_alert_by_name(alert)
         self._device.set_control_error("Play Alert", "" if result else "w")
         if result:
-            logger.info("Alert %s played on URRI %s", msg, self._urri_device.title)
+            logger.info("Alert %s played on URRI %s", alert, self._urri_device.title)
         else:
-            logger.warning("Alert %s not found on URRI %s", msg, self._urri_device.title)
+            logger.warning("Alert %s not found on URRI %s", alert, self._urri_device.title)
 
 
 class URRIDevice:

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -73,14 +73,14 @@ class MQTTDevice:
 
         self._device.create_control(
             "Next",
-            wbmqtt.ControlMeta(title="Next Track", control_type="pushbutton", order=6, read_only=False),
+            wbmqtt.ControlMeta(title="Next", control_type="pushbutton", order=6, read_only=False),
             "",
         )
         self._device.add_control_message_callback("Next", self.on_message_next_track)
 
         self._device.create_control(
             "Previous",
-            wbmqtt.ControlMeta(title="Previous Track", control_type="pushbutton", order=7, read_only=False),
+            wbmqtt.ControlMeta(title="Previous", control_type="pushbutton", order=7, read_only=False),
             "",
         )
         self._device.add_control_message_callback("Previous", self.on_message_previous_track)

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -72,18 +72,18 @@ class MQTTDevice:
         self._device.add_control_message_callback("AUX", self.on_message_aux)
 
         self._device.create_control(
-            "Next Track",
+            "Next",
             wbmqtt.ControlMeta(title="Next Track", control_type="pushbutton", order=6, read_only=False),
             "",
         )
-        self._device.add_control_message_callback("Next Track", self.on_message_next_track)
+        self._device.add_control_message_callback("Next", self.on_message_next_track)
 
         self._device.create_control(
-            "Previous Track",
+            "Previous",
             wbmqtt.ControlMeta(title="Previous Track", control_type="pushbutton", order=7, read_only=False),
             "",
         )
-        self._device.add_control_message_callback("Previous Track", self.on_message_previous_track)
+        self._device.add_control_message_callback("Previous", self.on_message_previous_track)
 
         self._device.create_control(
             "Source Type",
@@ -371,8 +371,8 @@ class URRIDevice:
 
             properties = {}
             readonly_properties = {
-                "Next Track": False,
-                "Previous Track": False,
+                "Next": False,
+                "Previous": False,
             }
 
             # get status by request
@@ -415,15 +415,13 @@ class URRIDevice:
                     properties["Preset ID"] = status_dict["source"]["index"]
 
                 if sourcetype in ["File System", "Preset"]:
-                    readonly_properties.update({"Next Track": False, "Previous Track": False})
+                    readonly_properties.update({"Next": False, "Previous": False})
                 elif sourcetype == "Spotify":
                     can_do_next = status_dict["source"].get("nextButton", False)
                     can_do_prev = status_dict["source"].get("prevButton", False)
-                    readonly_properties.update(
-                        {"Next Track": not can_do_next, "Previous Track": not can_do_prev}
-                    )
+                    readonly_properties.update({"Next": not can_do_next, "Previous": not can_do_prev})
                 else:
-                    readonly_properties.update({"Next Track": True, "Previous Track": True})
+                    readonly_properties.update({"Next": True, "Previous": True})
 
             # song title
             properties["Song Title"] = status_dict.get("songTitle", "No Title")
@@ -431,7 +429,7 @@ class URRIDevice:
             # aux
             if properties.get("AUX", False):
                 properties.update({"Source Type": "AUX", "Source Name": "AUX", "Song Title": ""})
-                readonly_properties.update({"Next Track": True, "Previous Track": True})
+                readonly_properties.update({"Next": True, "Previous": True})
 
             self._properties.update(properties)
 

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -151,7 +151,8 @@ class MQTTDevice:
 
     def set_error_state(self, error: bool):
         for control_name in self._device.get_controls_list():
-            self._device.set_control_error(control_name, "r" if error else "")
+            if control_name != "IP address":
+                self._device.set_control_error(control_name, "r" if error else "")
 
     def remove(self):
         self._device.remove_device()

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -334,6 +334,7 @@ class URRIDevice:
 
     def play_alert_by_name(self, alert_name: str):
         try:
+            alert_name = alert_name.removeprefix("/")
             alerts = self.get_alert_files()
             alert_id = alerts.index(alert_name)
 

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -223,8 +223,6 @@ class MQTTDevice:
         self._device.set_control_error("Play Folder", "" if result else "w")
         if result:
             logger.info("Play USB folder %s on URRI %s", folder, self._urri_device.title)
-        else:
-            logger.warning("USB Folder %s not found on URRI %s", folder, self._urri_device.title)
 
     def _on_message_play_alert(self, _, __, msg):
         alert = msg.payload.decode("utf-8")
@@ -352,11 +350,11 @@ class URRIDevice:
 
     def play_usb_folder(self, path: str):
         _, path_and_file = os.path.splitdrive(path)
-        path, file = os.path.split(path_and_file)
         path.removeprefix("/")
-
         if not path.endswith("/"):
             path += "/"
+
+        path, file = os.path.split(path_and_file)
 
         if not path.startswith("usb"):
             logger.warning("Play folder on URRI %s failed! Path %s is not USB", self._id, path)

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import os
 import signal
 import sys
 import threading
@@ -34,17 +35,6 @@ class MQTTDevice:
         self._root_topic = "/devices/" + self._urri_device.id
         logger.debug("Set URRI device %s on %s topic", self._urri_device.title, self._root_topic)
 
-    def _create_device(self, meta_options):
-        meta_json = json.dumps(meta_options, indent=0)
-        self._client.publish(self._root_topic + "/meta", meta_json, retain=True)
-
-    def _create_control(self, name, meta_options, callback):
-        meta_json = json.dumps(meta_options, indent=0)
-        self._client.publish(self._root_topic + "/controls/" + name + "/meta", meta_json, retain=True)
-        if callback is not None:
-            self._client.subscribe(self._root_topic + "/controls/" + name + "/on")
-            self._client.message_callback_add(self._root_topic + "/controls/" + name + "/on", callback)
-
     def publicate(self):
         self._device = wbmqtt.Device(
             mqtt_client=self._client,
@@ -53,15 +43,13 @@ class MQTTDevice:
             driver_name="wb-mqtt-urri",
         )
         self._device.create_control(
-            "Power", wbmqtt.ControlMeta(title="Статус", control_type="switch", order=1, read_only=False), ""
+            "Power", wbmqtt.ControlMeta(title="Power", control_type="switch", order=1, read_only=False), ""
         )
         self._device.add_control_message_callback("Power", self.on_message_power)
 
         self._device.create_control(
             "Volume",
-            wbmqtt.ControlMeta(
-                title="Громкость", control_type="range", order=2, read_only=False, max_value=100
-            ),
+            wbmqtt.ControlMeta(title="Volume", control_type="range", order=2, read_only=False, max_value=100),
             "",
         )
         self._device.add_control_message_callback("Volume", self.on_message_volume)
@@ -84,18 +72,18 @@ class MQTTDevice:
         self._device.add_control_message_callback("AUX", self.on_message_aux)
 
         self._device.create_control(
-            "Next",
-            wbmqtt.ControlMeta(title="Next", control_type="pushbutton", order=6, read_only=False),
+            "Next Track",
+            wbmqtt.ControlMeta(title="Next Track", control_type="pushbutton", order=6, read_only=False),
             "",
         )
-        self._device.add_control_message_callback("Next", self.on_message_next)
+        self._device.add_control_message_callback("Next Track", self.on_message_next_track)
 
         self._device.create_control(
-            "Previous",
-            wbmqtt.ControlMeta(title="Previous", control_type="pushbutton", order=7, read_only=False),
+            "Previous Track",
+            wbmqtt.ControlMeta(title="Previous Track", control_type="pushbutton", order=7, read_only=False),
             "",
         )
-        self._device.add_control_message_callback("Previous", self.on_message_previous)
+        self._device.add_control_message_callback("Previous Track", self.on_message_previous_track)
 
         self._device.create_control(
             "Source Type",
@@ -106,31 +94,56 @@ class MQTTDevice:
         self._device.create_control(
             "Radio ID",
             wbmqtt.ControlMeta(title="Radio ID", control_type="value", order=9, read_only=False),
-            "",
+            0,
         )
         self._device.add_control_message_callback("Radio ID", self.on_message_radioid)
 
         self._device.create_control(
+            "Preset ID",
+            wbmqtt.ControlMeta(
+                title="Preset ID", control_type="value", min_value=0, max_value=3, order=10, read_only=False
+            ),
+            0,
+        )
+        self._device.add_control_message_callback("Preset ID", self.on_message_presetid)
+
+        self._device.create_control(
             "Source Name",
-            wbmqtt.ControlMeta(title="Source Name", control_type="text", order=10, read_only=True),
+            wbmqtt.ControlMeta(title="Source Name", control_type="text", order=11, read_only=True),
             "",
         )
         self._device.create_control(
             "Song Title",
-            wbmqtt.ControlMeta(title="Song Title", control_type="text", order=11, read_only=True),
+            wbmqtt.ControlMeta(title="Song Title", control_type="text", order=12, read_only=True),
             "",
         )
         self._device.create_control(
             "IP address",
-            wbmqtt.ControlMeta(title="IP address", control_type="text", order=12, read_only=True),
+            wbmqtt.ControlMeta(title="IP address", control_type="text", order=13, read_only=True),
             self._urri_device.ip,
         )
+        self._device.create_control(
+            "Play Folder",
+            wbmqtt.ControlMeta(title="Play Folder", control_type="text", order=14, read_only=False),
+            "",
+        )
+        self._device.add_control_message_callback("Play Folder", self.on_message_play_folder)
+
+        self._device.create_control(
+            "Play Alert",
+            wbmqtt.ControlMeta(title="Play Alert", control_type="text", order=15, read_only=False),
+            "",
+        )
+        self._device.add_control_message_callback("Play Alert", self.on_message_play_alert)
         logger.info("%s device created", self._root_topic)
 
     def update(self, control_name, value):
-        control_topic = self._root_topic + "/controls/" + control_name
-        self._client.publish(control_topic, value, retain=True)
-        logger.debug("%s control updated with value %s", control_topic, value)
+        self._device.set_control_value(control_name, value)
+        logger.debug("%s %s control updated with value %s", self._urri_device.id, control_name, value)
+
+    def set_readonly(self, control_name, value):
+        self._device.set_control_read_only(control_name, value)
+        logger.debug("%s %s control readonly set to %s", self._urri_device.id, control_name, value)
 
     def on_message_power(self, _, __, msg):
         new_powerstate = "1" in str(msg.payload)
@@ -168,19 +181,54 @@ class MQTTDevice:
 
     def on_message_radioid(self, _, __, msg):
         radioid = int(str(msg.payload.decode("utf-8")))
-        self._urri_device.set_radioid(radioid)
-        logger.info("Set radio ID %s on URRI %s", radioid, self._urri_device.title)
+        result = self._urri_device.play_radio_by_id(radioid)
+        self._device.set_control_error("Radio ID", "" if result else "w")
+        if result:
+            logger.info("Set radio ID %s on URRI %s", radioid, self._urri_device.title)
+        else:
+            logger.warning("Radio ID %s not found on URRI %s", radioid, self._urri_device.title)
 
-    def on_message_next(self, _, __, ___):
-        self._urri_device.set_next()
-        logger.info("Set next track on URRI %s", self._urri_device.title)
+    def on_message_presetid(self, _, __, msg):
+        presetid = int(str(msg.payload.decode("utf-8")))
+        self._urri_device.play_preset_by_number(presetid)
+        logger.info("Set preset ID %s on URRI %s", presetid, self._urri_device.title)
 
-    def on_message_previous(self, _, __, ___):
-        self._urri_device.set_previous()
-        logger.info("Set previous track on URRI %s", self._urri_device.title)
+    def on_message_next_track(self, _, __, ___):
+        self._urri_device.play_next_track()
+        logger.info("Play next track on URRI %s", self._urri_device.title)
+
+    def on_message_previous_track(self, _, __, ___):
+        self._urri_device.play_previous_track()
+        logger.info("Play previous track on URRI %s", self._urri_device.title)
+
+    def on_message_play_folder(self, _, __, msg):
+        result = self._urri_device.play_usb_folder(msg.payload.decode("utf-8"))
+        self._device.set_control_error("Play Folder", "" if result else "w")
+        if result:
+            logger.info("Play USB folder %s on URRI %s", msg, self._urri_device.title)
+        else:
+            logger.warning("USB Folder %s not found on URRI %s", msg, self._urri_device.title)
+
+    def on_message_play_alert(self, _, __, msg):
+        result = self._urri_device.play_alert_by_name(msg.payload.decode("utf-8"))
+        self._device.set_control_error("Play Alert", "" if result else "w")
+        if result:
+            logger.info("Alert %s played on URRI %s", msg, self._urri_device.title)
+        else:
+            logger.warning("Alert %s not found on URRI %s", msg, self._urri_device.title)
 
 
 class URRIDevice:
+    SOURCE_TYPES = {
+        0: "Internet Radio",
+        1: "File System",
+        2: "Preset",
+        3: "Multiroom Slave",
+        4: "Airplay",
+        5: "User Internet Radio",
+        6: "Spotify",
+    }
+
     def __init__(self, properties):
         self._id = properties["device_id"]
         self._title = properties["device_title"]
@@ -188,6 +236,8 @@ class URRIDevice:
         self._url = f"http://{properties['urri_ip']}:{properties['urri_port']}"
         self._urri_client = socketio.Client(logger=False, engineio_logger=False)
         self._mqtt_device = None
+
+        self._properties = {}
 
         logger.debug("Add device with id " + self._id + " and title " + self._title)
 
@@ -236,20 +286,74 @@ class URRIDevice:
 
     def set_volume(self, volume: int):
         if 0 <= volume <= 100:
-            out_url = "/setVolume/" + str(volume)
-            requests.post(url=(self._url + out_url), timeout=3)
+            requests.post(url=f"{self._url}/setVolume/{volume}", timeout=3)
 
-    def set_radioid(self, radioid: int):
+    def play_radio_by_id(self, radioid: int):
         out_headers = {"Content-Type": "application/json"}
-        out_url = "/radio"
         out_data = {"id": radioid}
-        out_json = json.dumps(out_data)
-        requests.post(headers=out_headers, url=(self._url + out_url), data=out_json, timeout=3)
+        response = requests.post(
+            headers=out_headers, url=f"{self._url}/radio", data=json.dumps(out_data), timeout=3
+        )
+        logger.debug("Play radio by id response: %s %s", self._id, response.json())
+        return response.json()["success"]
 
-    def set_next(self):
-        requests.post(url=(self._url + "/next"), timeout=3)
+    def play_preset_by_number(self, preset_number: int):
+        response = requests.post(url=f"{self._url}/preset/{preset_number}/play", timeout=3)
+        logger.debug("Play preset by number response: %s %s", self._id, response.json())
 
-    def set_previous(self):
+    def get_alert_files(self):
+        response = requests.post(url=f"{self._url}/alert/getSongs", timeout=3)
+        logger.debug("Get alert files response: %s %s", self._id, response.json())
+        return response.json()
+
+    def play_alert_by_name(self, alert_name: str):
+        try:
+            alerts = self.get_alert_files()
+            alert_id = alerts.index(alert_name)
+
+            out_headers = {"Content-Type": "application/json"}
+            out_data = {"fileIndex": alert_id}
+            response = requests.post(
+                headers=out_headers, url=f"{self._url}/alert/notify", data=json.dumps(out_data), timeout=3
+            )
+            logger.debug("Play alert by name response: %s %s", self._id, response.json())
+            return response.json()["success"]
+        except ValueError:
+            logger.debug("Alert %s %s not found", self._id, alert_name)
+            return False
+
+    def play_usb_folder(self, path: str):
+        _, path_and_file = os.path.splitdrive(path)
+        path, file = os.path.split(path_and_file)
+        path.removeprefix("/")
+
+        if not path.endswith("/"):
+            path += "/"
+
+        if not path.startswith("usb"):
+            logger.warning("Play folder on URRI %s failed! Path %s is not USB", self._id, path)
+            return False
+
+        if file != "":
+            logger.warning("Play folder on URRI %s failed! File %s is not folder", self._id, file)
+            return False
+
+        out_headers = {"Content-Type": "application/json"}
+        out_data = {"path": path}
+        response = requests.post(
+            headers=out_headers,
+            url=(self._url + "/sources/usb/play"),
+            data=json.dumps(out_data),
+            timeout=3,
+        )
+        logger.debug("Play USB folder response: %s %s", self._id, response.json())
+        return response.json()["success"]
+
+    def play_next_track(self):
+        response = requests.post(url=f"{self._url}/next", timeout=3)
+        logger.debug("Play next track response: %s", response.json())
+
+    def play_previous_track(self):
         requests.post(url=(self._url + "/previous"), timeout=3)
 
     def _init_callbacks(self):
@@ -265,64 +369,79 @@ class URRIDevice:
         def on_status_message(status_dict):
             logger.debug("URRI status message received: %s", status_dict)
 
+            properties = {}
+            readonly_properties = {
+                "Next Track": False,
+                "Previous Track": False,
+            }
+
             # get status by request
-            self._mqtt_device.update("Power", "1" if self.get_power() else "0")
+            properties["Power"] = self.get_power()
 
             # playback status
             if "playback" in status_dict:
-                playback = "1" if "play" in str(status_dict["playback"]) else "0"
-                self._mqtt_device.update("Playback", playback)
+                properties["Playback"] = status_dict["playback"] == "play"
 
             # AUX status
             if "AUX" in status_dict:
-                aux = "1" if "True" in str(status_dict["AUX"]) else "0"
-                self._mqtt_device.update("AUX", aux)
+                properties["AUX"] = status_dict["AUX"]
 
             # muted status
             if "muted" in status_dict:
-                muted = "1" if "True" in str(status_dict["muted"]) else "0"
-                self._mqtt_device.update("Mute", muted)
+                properties["Mute"] = status_dict["muted"]
 
             # volume
             if "volume" in status_dict:
-                volume = str(status_dict["volume"])
-                self._mqtt_device.update("Volume", volume)
+                properties["Volume"] = status_dict["volume"]
 
             # source type, name, id
             if "source" in status_dict:
-                if "sourceType" in status_dict["source"]:
-                    type_id = status_dict["source"]["sourceType"]
-                    source_types = {
-                        0: "Internet Radio",
-                        1: "File System",
-                        2: "Preset",
-                        3: "Multiroom Slave",
-                        4: "Airplay",
-                        5: "User Internet Radio",
-                        6: "Spotify",
-                    }
-                    sourcetype = source_types.get(type_id, "Unknown")
+                type_id = status_dict["source"]["sourceType"]
+                sourcetype = self.SOURCE_TYPES.get(type_id, "Unknown")
+                properties["Source Type"] = sourcetype
+                properties["Set Source"] = type_id
 
-                    self._mqtt_device.update("Source Type", sourcetype)
+                if sourcetype in ["Internet Radio", "Preset", "User Internet Radio", "Spotify"]:
+                    properties["Source Name"] = status_dict["source"]["name"]
+                elif sourcetype == "File System":
+                    properties["Source Name"] = status_dict["source"]["path"]
+                else:
+                    properties["Source Name"] = ""
 
-                if "name" in status_dict["source"]:
-                    sourcename = status_dict["source"]["name"]
-                    self._mqtt_device.update("Source Name", sourcename)
+                if sourcetype in ["Internet Radio", "User Internet Radio"]:
+                    properties["Radio ID"] = status_dict["source"]["id"]
+                elif sourcetype == "Preset":
+                    properties["Radio ID"] = status_dict["source"]["id"]
+                    properties["Preset ID"] = status_dict["source"]["index"]
 
-                if "path" in status_dict["source"]:
-                    sourcename = status_dict["source"]["path"]
-                    self._mqtt_device.update("Source Name", sourcename)
-
-                if "id" in status_dict["source"]:
-                    radioid = str(status_dict["source"]["id"])
-                    self._mqtt_device.update("Radio ID", radioid)
+                if sourcetype in ["File System", "Preset"]:
+                    readonly_properties.update({"Next Track": False, "Previous Track": False})
+                elif sourcetype == "Spotify":
+                    can_do_next = status_dict["source"].get("nextButton", False)
+                    can_do_prev = status_dict["source"].get("prevButton", False)
+                    readonly_properties.update(
+                        {"Next Track": not can_do_next, "Previous Track": not can_do_prev}
+                    )
+                else:
+                    readonly_properties.update({"Next Track": True, "Previous Track": True})
 
             # song title
-            if "songTitle" in status_dict:
-                songtitle = "" if aux == "1" else str(status_dict["songTitle"])
-                self._mqtt_device.update("Song Title", songtitle)
-            else:
-                self._mqtt_device.update("Song Title", "No Title")
+            properties["Song Title"] = status_dict.get("songTitle", "No Title")
+
+            # aux
+            if properties.get("AUX", False):
+                properties.update({"Source Type": "AUX", "Source Name": "AUX", "Song Title": ""})
+                readonly_properties.update({"Next Track": True, "Previous Track": True})
+
+            self._properties.update(properties)
+
+            for key, value in properties.items():
+                if type(value) is bool:
+                    value = "1" if value else "0"
+                self._mqtt_device.update(key, value)
+
+            for key, value in readonly_properties.items():
+                self._mqtt_device.set_readonly(key, value)
 
 
 class ConfigHandler(pyinotify.ProcessEvent):

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -350,9 +350,9 @@ class URRIDevice:
 
     def play_usb_folder(self, path: str):
         _, path_and_file = os.path.splitdrive(path)
-        path.removeprefix("/")
-        if not path.endswith("/"):
-            path += "/"
+        path_and_file.removeprefix("/")
+        if not path_and_file.endswith("/"):
+            path_and_file += "/"
 
         path, file = os.path.split(path_and_file)
 
@@ -361,7 +361,7 @@ class URRIDevice:
             return False
 
         if file != "":
-            logger.warning("Play folder on URRI %s failed! File %s is not folder", self._id, file)
+            logger.warning("Play folder on URRI %s failed! File %s is not a folder", self._id, file)
             return False
 
         out_headers = {"Content-Type": "application/json"}

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -350,7 +350,7 @@ class URRIDevice:
 
     def play_usb_folder(self, path: str):
         _, path_and_file = os.path.splitdrive(path)
-        path_and_file.removeprefix("/")
+        path_and_file = path_and_file.removeprefix("/")
         if not path_and_file.endswith("/"):
             path_and_file += "/"
 

--- a/wb_mqtt_urri/wbmqtt.py
+++ b/wb_mqtt_urri/wbmqtt.py
@@ -13,6 +13,7 @@ class ControlMeta:  # pylint: disable=R0903,disable=R0913
         read_only: bool = False,
         min_value: int = None,
         max_value: int = None,
+        error: str = None,
     ) -> None:
         self.title = title
         self.control_type = control_type
@@ -20,6 +21,7 @@ class ControlMeta:  # pylint: disable=R0903,disable=R0913
         self.read_only = read_only
         self.min_value = min_value
         self.max_value = max_value
+        self.error = error
 
 
 class ControlState:  # pylint: disable=R0903
@@ -80,6 +82,15 @@ class Device:
         else:
             logging.debug("Can't set title of undeclared control %s", mqtt_control_name)
 
+    def set_control_error(self, mqtt_control_name: str, error: str) -> None:
+        if mqtt_control_name in self._controls:
+            control = self._controls[mqtt_control_name]
+            if control.meta.error != error:
+                control.meta.error = error
+                self._publish_control_meta(mqtt_control_name, control.meta)
+        else:
+            logging.debug("Can't set error of undeclared control %s", mqtt_control_name)
+
     def add_control_message_callback(self, mqtt_control_name: str, callback: callable) -> None:
         if mqtt_control_name in self._controls:
             control_base_topic = self._get_control_base_topic(mqtt_control_name)
@@ -98,12 +109,13 @@ class Device:
         }
         if meta.title is not None:
             meta_dict["title"] = {"en": meta.title}
-        if meta.order is not None:
-            meta_dict["order"] = meta.order
         if meta.min_value is not None:
             meta_dict["min"] = meta.min_value
         if meta.max_value is not None:
             meta_dict["max"] = meta.max_value
+        for key in ["order", "error"]:
+            if getattr(meta, key) is not None:
+                meta_dict[key] = getattr(meta, key)
 
         if meta_dict:
             meta_json = json.dumps(meta_dict)


### PR DESCRIPTION
Добавила возможность проигрывать алерты (конкретные треки-уведомления из папки alerts на устройстве и usb-носителе), пресет по номеру и usb-папки. Воспроизвести конкретный файл из обычной папки (не из папки алертов) не получится из за ограничений API: в информации о файлах в папке он не выводит пути к файлам.
deb http://deb.wirenboard.com/all experimental.test-urri-file main
Еще поправила AUX режим.