### PR TITLE
Add -c/--config argument

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-urri (1.1.3) stable; urgency=medium
+
+  * Add -c/--config argument
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 31 Dec 2024 14:21:00 +0400
+
 wb-mqtt-urri (1.1.2) stable; urgency=medium
 
   * Add handling of cases when cannot establish connection to urri device

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -482,14 +482,15 @@ def main(argv):
         action="store_true",
         help="Make JSON for wb-mqtt-confed from /etc/wb-mqtt-urri.conf",
     )
+    parser.add_argument("-c", "--config", type=str, default=CONFIG_FILEPATH, help="Config file")
     args = parser.parse_args(argv[1:])
 
     if args.j:
-        config = to_json(CONFIG_FILEPATH)
+        config = to_json(args.config)
         json.dump(config, sys.stdout, sort_keys=True, indent=2)
         return 0
 
-    config = read_and_validate_config(CONFIG_FILEPATH, SCHEMA_FILEPATH)
+    config = read_and_validate_config(args.config, SCHEMA_FILEPATH)
     if config is None:
         return 6  # systemd status=6/NOTCONFIGURED
     if config["debug"]:


### PR DESCRIPTION
Все wb сервисы позволяют передавать кастомный конфиг аргументом, что удобно при отладке и тестировании.