### PR TITLE
Fix receiver IP address validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ debian/debhelper-build-stamp
 .DS_Store
 venv
 .venv
+
+### direnv ###
+.direnv
+.envrc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,3 @@
 buildDebArchAll defaultRunLintian: true,
-                defaultRunPythonChecks: true
+                defaultRunPythonChecks: true,
+                defaultAngryPylint: true

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-urri (1.2.2) stable; urgency=medium
+
+  * Fix receiver IP address validation
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 01 Aug 2024 12:31:00 +0400
+
 wb-mqtt-urri (1.2.1) stable; urgency=medium
 
   * Add -c/--config argument

--- a/wb-mqtt-urri.schema.json
+++ b/wb-mqtt-urri.schema.json
@@ -30,10 +30,13 @@
                 },
                 "urri_ip": {
                     "type": "string",
-                    "title": "Receiver API IP address",
-                    "default": "",
+                    "title": "Receiver API address",
                     "propertyOrder": 3,
-                    "format": "ipv4"
+                    "oneOf": [
+                        { "format": "ipv4" },
+                        { "format": "ipv6" },
+                        { "format": "hostname" }
+                    ]
                 },
                 "urri_port": {
                     "type": "number",
@@ -97,7 +100,7 @@
             "Enable debug logging": "Режим отладки",
             "MQTT id of the device": "Идентификатор устройства в MQTT",
             "Device name": "Название устройства",
-            "Receiver API IP address": "IP-адрес API ресивера",
+            "Receiver API address": "Адрес API ресивера",
             "Receiver API port": "Порт API ресивера"
         }
     }    

--- a/wb-mqtt-urri.schema.json
+++ b/wb-mqtt-urri.schema.json
@@ -30,13 +30,9 @@
                 },
                 "urri_ip": {
                     "type": "string",
-                    "title": "Receiver API address",
+                    "title": "IP address or hostname of receiver API",
                     "propertyOrder": 3,
-                    "oneOf": [
-                        { "format": "ipv4" },
-                        { "format": "ipv6" },
-                        { "format": "hostname" }
-                    ]
+                    "minLength": 1
                 },
                 "urri_port": {
                     "type": "number",
@@ -100,7 +96,7 @@
             "Enable debug logging": "Режим отладки",
             "MQTT id of the device": "Идентификатор устройства в MQTT",
             "Device name": "Название устройства",
-            "Receiver API address": "Адрес API ресивера",
+            "IP address or hostname of receiver API": "IP адрес или доменное имя API ресивера",
             "Receiver API port": "Порт API ресивера"
         }
     }    

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -260,7 +260,7 @@ class URRIDevice:
         logger.debug("Add device with id " + self._id + " and title " + self._title)
 
     @property
-    def id(self):  # pylint: disable=C0103
+    def id(self):  # pylint: disable=invalid-name
         return self._id
 
     @property
@@ -390,7 +390,7 @@ class URRIDevice:
             logger.info("Connected to URRI %s", self._url)
 
         @self._urri_client.on("status")
-        async def on_status_message(status_dict):
+        async def on_status_message(status_dict):  # pylint: disable=too-many-branches
             logger.debug("URRI status message received: %s", status_dict)
 
             properties = {}
@@ -458,7 +458,7 @@ class URRIDevice:
             self._properties.update(properties)
 
             for key, value in properties.items():
-                if type(value) is bool:
+                if isinstance(value, bool):
                     value = "1" if value else "0"
                 self._mqtt_device.update(key, value)
 
@@ -466,7 +466,7 @@ class URRIDevice:
                 self._mqtt_device.set_readonly(key, value)
 
 
-class URRIClient:
+class URRIClient:  # pylint: disable=too-few-public-methods
     def __init__(self, devices_config) -> None:
         self.mqtt_client_running = False
         self.devices_config = devices_config
@@ -547,7 +547,7 @@ def read_and_validate_config(config_filepath: str, schema_filepath: str) -> dict
         try:
             config = json.load(config_file)
             schema = json.load(schema_file)
-            jsonschema.validate(config, schema)
+            jsonschema.validate(config, schema, format_checker=jsonschema.draft4_format_checker)
 
             if config.get("device_id") is not None:
                 logger.error("Old version of config file! Please update it")

--- a/wb_mqtt_urri/wbmqtt.py
+++ b/wb_mqtt_urri/wbmqtt.py
@@ -4,7 +4,7 @@ import random
 import threading
 
 
-class ControlMeta:  # pylint: disable=R0903,disable=R0913
+class ControlMeta:  # pylint: disable=too-few-public-methods,disable=too-many-arguments
     def __init__(
         self,
         title: str = None,
@@ -24,7 +24,7 @@ class ControlMeta:  # pylint: disable=R0903,disable=R0913
         self.error = error
 
 
-class ControlState:  # pylint: disable=R0903
+class ControlState:  # pylint: disable=too-few-public-methods
     def __init__(self, meta: ControlMeta, value: str) -> None:
         self.meta = ControlMeta(
             meta.title, meta.control_type, meta.order, meta.read_only, meta.min, meta.max, meta.error
@@ -142,7 +142,7 @@ def retain_hack(mqtt_client) -> None:
     mqtt_client.subscribe(retain_hack_topic)
     mqtt_client.message_callback_add(retain_hack_topic, on_retain_hack)
     mqtt_client.publish(retain_hack_topic, "2", qos=2)
-    sem.acquire(timeout=10)  # pylint: disable=R1732
+    sem.acquire(timeout=10)  # pylint: disable=consider-using-with
     mqtt_client.unsubscribe(retain_hack_topic)
     mqtt_client.message_callback_remove(retain_hack_topic)
 


### PR DESCRIPTION
Default config with empty urri_ip:
```sh
cat /etc/wb-mqtt-urri.conf | jq '.devices[0].urri_ip'
""
```

Before:
```sh
wb-mqtt-urri -c /etc/wb-mqtt-urri.conf
INFO: URRI service starting
INFO: MQTT client connected
INFO: /devices/urri device created
ERROR: URRI urri connection error: Connection refused by the server
ERROR: URRI urri connection error: Connection refused by the server
ERROR: URRI urri connection error: Connection refused by the server
...
```

After:
```sh
wb-mqtt-urri -c /etc/wb-mqtt-urri.conf
INFO: URRI service starting
ERROR: Config file validation failed! Error: '' is not a 'ipv4'

Failed validating 'format' in schema['properties']['devices']['items']['properties']['urri_ip']:
    {'format': 'ipv4',
     'propertyOrder': 3,
     'title': 'Receiver API IP address',
     'type': 'string'}

On instance['devices'][0]['urri_ip']:
    ''
```
exit status=6/NOTCONFIGURED

More details: https://github.com/python-jsonschema/jsonschema/blob/v3.2.0/docs/validate.rst#the-validator-interface
