### PR TITLE
Add .postrm script

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,15 @@
+wb-mqtt-urri (1.2.4) stable; urgency=medium
+
+  * Add .postrm script, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 26 Sep 2024 17:40:00 +0400
+
 wb-mqtt-urri (1.2.3) stable; urgency=medium
 
   * Rebublish mqtt devices after mosquitto restart 
   * Add test
 
- --  Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 19 Sep 2024 14:32:57 +0300
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 19 Sep 2024 14:32:57 +0300
 
 wb-mqtt-urri (1.2.2) stable; urgency=medium
 

--- a/debian/wb-mqtt-urri.postrm
+++ b/debian/wb-mqtt-urri.postrm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/debian/wb-mqtt-urri.postrm
+++ b/debian/wb-mqtt-urri.postrm
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+CONFFILE=/etc/wb-mqtt-urri.conf
+
+if [ "$1" = "purge" ]; then
+    rm -f $CONFFILE
+fi
+
+#DEBHELPER#


### PR DESCRIPTION
How to reproduce:
```sh
apt install wb-mqtt-urri
wb-configs-early start # or reboot
apt purge wb-mqtt-urri
ls -la /etc/wb-mqtt-urri.conf
lrwxrwxrwx 1 root root 31 Sep 26 14:47 /etc/wb-mqtt-urri.conf -> /mnt/data/etc/wb-mqtt-urri.conf
ls -la /mnt/data/etc/wb-mqtt-urri.conf
ls: cannot access '/mnt/data/etc/wb-mqtt-urri.conf': No such file or directory
apt install wb-mqtt-urri
ls -la /etc/wb-mqtt-urri.conf
lrwxrwxrwx 1 root root 31 Sep 26 14:47 /etc/wb-mqtt-urri.conf -> /mnt/data/etc/wb-mqtt-urri.conf
ls -la /mnt/data/etc/wb-mqtt-urri.conf
ls: cannot access '/mnt/data/etc/wb-mqtt-urri.conf': No such file or directory
```

Log:
```sh
FileNotFoundError: [Errno 2] No such file or directory: '/etc/wb-mqtt-urri.conf'
```