### PR TITLE
Cleanup topics on service stop

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-urri (1.2.5) stable; urgency=medium
+
+  * Cleanup topics on service stop
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 04 Nov 2024 16:00:00 +0400
+
 wb-mqtt-urri (1.2.4) stable; urgency=medium
 
   * Add .postrm script, no functional changes
@@ -6,7 +12,7 @@ wb-mqtt-urri (1.2.4) stable; urgency=medium
 
 wb-mqtt-urri (1.2.3) stable; urgency=medium
 
-  * Rebublish mqtt devices after mosquitto restart 
+  * Rebublish mqtt devices after mosquitto restart
   * Add test
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 19 Sep 2024 14:32:57 +0300

--- a/tests/test_urri_client.py
+++ b/tests/test_urri_client.py
@@ -36,6 +36,7 @@ def test_mosquitto_restart(mocker):
     mocked = mocker.patch("wb_mqtt_urri.main.MQTTClient")
     mocked.return_value.publish.side_effect = publish
     mocker.patch("wb_mqtt_urri.main.URRIDevice", side_effect=URRIDeviceMock)
+    mocker.patch("wb_mqtt_urri.main.MQTTDevice.remove")
     urri_client = URRIClient(TEST_CONFIG["devices"])
 
     asyncio.run(urri_client.run())

--- a/wb_mqtt_urri/main.py
+++ b/wb_mqtt_urri/main.py
@@ -540,7 +540,8 @@ class URRIClient:  # pylint: disable=too-few-public-methods
             return 0
         finally:
             await asyncio.gather(*[urri_device.stop() for urri_device in self._urri_devices])
-
+            for mqtt_device in self._mqtt_devices:
+                mqtt_device.remove()
             self._mqtt_client.stop()
             logger.debug("MQTT client stopped")
 


### PR DESCRIPTION
Test instruction:
```sh
$ systemctl stop wb-mqtt-urri
$ mqtt-get-dump /devices/urri/#
```