### PR TITLE
Fix build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-urri (1.2.7) stable; urgency=medium
+
+  * Add missed build dep, adopt PEP440
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 25 Apr 2025 02:00:00 +0400
+
 wb-mqtt-urri (1.2.6) stable; urgency=medium
 
   * Fix lintian

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: wb-mqtt-urri
 Maintainer: Wiren Board Team <info@wirenboard.com>
 Section: misc
 Priority: optional
-Build-Depends: dh-python, debhelper-compat (= 13), python3, python3-jsonschema, python3-socketio, python3-pytest, python3-pytest-mock
+Build-Depends: dh-python, debhelper-compat (= 13), python3, python3-wb-common (>= 2.1.0~~), python3-jsonschema, python3-socketio, python3-pytest, python3-pytest-mock
 Standards-Version: 4.5.1
 X-Python3-Version: >= 3.9
 Homepage: https://github.com/wirenboard/wb-mqtt-urri

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 def get_version():
     with open("debian/changelog", "r", encoding="utf-8") as f:
-        return f.readline().split()[1][1:-1]
+        return f.readline().split()[1][1:-1].split("~")[0]
 
 
 setup(


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Fix build error:
```sh
__________________ ERROR collecting tests/test_urri_client.py __________________
ImportError while importing test module '/<<PKGBUILDDIR>>/.pybuild/cpython3_3.13/build/tests/test_urri_client.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_urri_client.py:3: in <module>
    from wb_mqtt_urri.main import URRIClient
wb_mqtt_urri/main.py:13: in <module>
    from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
E   ModuleNotFoundError: No module named 'wb_common'
```

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


