### PR TITLE
Add device_id validation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-urri (1.2.8) stable; urgency=medium
+
+  * Add device_id validation
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 30 Jul 2025 15:00:00 +0400
+
 wb-mqtt-urri (1.2.7) stable; urgency=medium
 
   * Add missed build dep, adopt PEP440

--- a/wb-mqtt-urri.schema.json
+++ b/wb-mqtt-urri.schema.json
@@ -17,9 +17,13 @@
                 "device_id": {
                     "type": "string",
                     "title": "MQTT id of the device",
+                    "pattern": "^[^$#+\\/]+$",
                     "default": "",
                     "minLength": 1,
-                    "propertyOrder": 1
+                    "propertyOrder": 1,
+                    "options": {
+                        "patternmessage": "Invalid device name"
+                    }
                 },
                 "device_title": {
                     "type": "string",
@@ -92,6 +96,7 @@
         "ru": {
             "URRI Receivers": "Ресиверы URRI",
             "Device": "Устройство",
+            "Invalid device name": "Неверное имя устройства",
             "URRI receiver settings": "Настройка ресиверов URRI",
             "Enable debug logging": "Режим отладки",
             "MQTT id of the device": "Идентификатор устройства в MQTT",


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Аналогично недавнему фиксу в рулесах https://github.com/wirenboard/wb-rules/pull/163, тут тоже device_id никак не валидировался.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
на вб
<img width="726" height="186" alt="Screen Shot 2025-07-30 at 23 21 13" src="https://github.com/user-attachments/assets/844cc71b-2b6f-4e2f-b106-76f3d5d797c0" />

